### PR TITLE
Octave too high

### DIFF
--- a/samplerbox.py
+++ b/samplerbox.py
@@ -276,7 +276,7 @@ def ActuallyLoad():
                         midinote = int(info.get('midinote', defaultparams['midinote']))
                         velocity = int(info.get('velocity', defaultparams['velocity']))
                         notename = info.get('notename', defaultparams['notename'])
-                        if notename: midinote = NOTES.index(notename[:-1].lower()) + (int(notename[-1])+2) * 12
+                        if notename: midinote = NOTES.index(notename[:-1].lower()) + (int(notename[-1])) * 12
                         samples[midinote, velocity] = Sound(os.path.join(dirname, fname), midinote, velocity)
 
     else:


### PR DESCRIPTION
On Grand Piano samples,
When i play a b4 (midinote:59) it played b2v*.wav

In ActuallyLoad() I remove +2 and it seems to works correctly.

Midinote to octave and notes
http://www.midimountain.com/midi/midi_note_numbers.html
