### PR TITLE
Remove pyaudio from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommende
 
   ~~~
   sudo apt-get update ; sudo apt-get -y install git python-dev python-pip python-numpy cython python-smbus portaudio19-dev libportaudio2 libffi-dev
-  sudo pip install rtmidi-python pyaudio cffi sounddevice
+  sudo pip install rtmidi-python cffi sounddevice
   ~~~
 
 2. Download SamplerBox and build it with: 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommende
 1. Install the required dependencies (Python-related packages and audio libraries):
 
   ~~~
-  sudo apt-get update ; sudo apt-get -y install git python-dev python-pip python-numpy cython python-smbus portaudio19-dev libportaudio2 libffi-dev
+  sudo apt-get update ; sudo apt-get -y install git python-dev python-pip python-numpy cython python-smbus libportaudio2 libffi-dev
   sudo pip install rtmidi-python cffi sounddevice
   ~~~
 

--- a/isoimage/samplerbox_iso_maker.sh
+++ b/isoimage/samplerbox_iso_maker.sh
@@ -113,7 +113,7 @@ chroot sdcard apt-get clean
 chroot sdcard apt-get -y install build-essential python-dev python-pip cython python-smbus python-numpy python-rpi.gpio python-serial portaudio19-dev alsa-utils git libportaudio2 libffi-dev
 chroot sdcard apt-get clean
 chroot sdcard apt-get autoremove -y
-chroot sdcard pip install rtmidi-python pyaudio cffi sounddevice
+chroot sdcard pip install rtmidi-python cffi sounddevice
 
 # Allowing root to log into $release with password... "
 sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' sdcard/etc/ssh/sshd_config

--- a/isoimage/samplerbox_iso_maker.sh
+++ b/isoimage/samplerbox_iso_maker.sh
@@ -110,7 +110,7 @@ chroot sdcard apt-get -y upgrade
 chroot sdcard apt-get -y dist-upgrade
 chroot sdcard apt-get -y install libraspberrypi-bin libraspberrypi-dev libraspberrypi0 raspberrypi-bootloader ssh wireless-tools wpasupplicant usbutils
 chroot sdcard apt-get clean
-chroot sdcard apt-get -y install build-essential python-dev python-pip cython python-smbus python-numpy python-rpi.gpio python-serial portaudio19-dev alsa-utils git libportaudio2 libffi-dev
+chroot sdcard apt-get -y install build-essential python-dev python-pip cython python-smbus python-numpy python-rpi.gpio python-serial alsa-utils git libportaudio2 libffi-dev
 chroot sdcard apt-get clean
 chroot sdcard apt-get autoremove -y
 chroot sdcard pip install rtmidi-python cffi sounddevice


### PR DESCRIPTION
The `sounddevice` module doesn't need `portaudio19-dev`, because it doesn't compile anything.

I'm not sure if you need it for something else, though, so I put that in a separate commit for you to drop if that's the case.