### PR TITLE
Make samplerbox.py work with rtmidi-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommende
 
   ~~~
   sudo apt-get update ; sudo apt-get -y install git python-dev python-pip python-numpy cython python-smbus libportaudio2 libffi-dev
-  sudo pip install rtmidi-python cffi sounddevice
+  sudo pip install python-rtmidi cffi sounddevice
   ~~~
 
 2. Download SamplerBox and build it with:

--- a/isoimage/maker.sh
+++ b/isoimage/maker.sh
@@ -20,7 +20,7 @@ mount -v -t vfat -o sync /dev/mapper/loop0p1 sdcard/boot
 echo root:root | chroot sdcard chpasswd
 chroot sdcard apt update
 chroot sdcard apt install -y build-essential python-dev python-pip cython python-smbus python-numpy python-rpi.gpio python-serial portaudio19-dev alsa-utils git libportaudio2 libffi-dev raspberrypi-kernel ntpdate
-chroot sdcard pip install rtmidi-python pyaudio cffi sounddevice
+chroot sdcard pip install python-rtmidi pyaudio cffi sounddevice
 chroot sdcard sh -c "cd /root ; git clone https://github.com/josephernest/SamplerBox.git ; cd SamplerBox ; python setup.py build_ext --inplace"
 cp -R root/* sdcard
 chroot sdcard systemctl enable /etc/systemd/system/samplerbox.service

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -36,7 +36,7 @@ import sounddevice
 import threading
 from chunk import Chunk
 import struct
-import rtmidi_python as rtmidi
+import rtmidi
 import samplerbox_audio
 
 
@@ -481,11 +481,11 @@ if USE_SYSTEMLED:
 midi_in = [rtmidi.MidiIn()]
 previous = []
 while True:
-    for port in midi_in[0].ports:
+    for port in midi_in[0].get_ports():
         if port not in previous and 'Midi Through' not in port:
             midi_in.append(rtmidi.MidiIn())
             midi_in[-1].callback = MidiCallback
             midi_in[-1].open_port(port)
             print 'Opened MIDI: ' + port
-    previous = midi_in[0].ports
+    previous = midi_in[0].get_ports()
     time.sleep(2)


### PR DESCRIPTION
I'm having troubles installing `rtmidi_python` on Windows. After checking, it seems like the project is pretty abandoned.
In order to make SamplerBox working on my PC, I had to switch to `python-rtmidi` instead (and make changes necessary for python 3 compatibility as I didn't want to install python 2.7).

This is a trivial patch that makes this possible.