### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Website: [www.samplerbox.org](https://www.samplerbox.org)
 [Install](#install)
 ----
 
-SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommended to use a USB DAC (PCM7204 USB DAC for less than 10€ on eBay is fine) for better sound quality.
+SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommended to use a USB DAC (PCM2704 USB DAC for less than 10€ on eBay is fine) for better sound quality.
 
 1. Install the required dependencies (Python-related packages and audio libraries):
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommende
   sudo pip install rtmidi-python pyaudio cffi sounddevice
   ~~~
 
-2. Download SamplerBox and build it with: 
+2. Download SamplerBox and build it with:
 
   ~~~
   git clone https://github.com/josephernest/SamplerBox.git
@@ -32,7 +32,7 @@ SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommende
 
 3. Run the soft with `python samplerbox.py`.
 
-4. Play some notes on the connected MIDI keyboard, you'll hear some sound!  
+4. Play some notes on the connected MIDI keyboard, you'll hear some sound!
 
 *(Optional)*  Modify `samplerbox.py`'s first lines if you want to change root directory for sample-sets, default soundcard, etc.
 

--- a/isoimage/samplerbox_iso_maker.sh
+++ b/isoimage/samplerbox_iso_maker.sh
@@ -81,7 +81,7 @@ cat <<EOF > sdcard/boot/config.txt
 device_tree_param=i2c_arm=on
 enable_uart=1
 dtoverlay=pi3-miniuart-bt
-dtoverlay=midi-uart0 
+dtoverlay=midi-uart0
 gpu_mem=64
 boot_delay=0
 disable_splash=1


### PR DESCRIPTION
Fix a typo in component name (a0b7e64c69b8dae8ce861fecf3063ff2d24146df).

This probably closes #23.