### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommende
 
   ~~~
   sudo apt-get update ; sudo apt-get -y install git python-dev python-pip python-numpy cython python-smbus libportaudio2 libffi-dev
-  sudo pip install rtmidi-python cffi sounddevice
+  sudo pip install python-rtmidi cffi sounddevice
   ~~~
 
 2. Download SamplerBox and build it with:

--- a/isoimage/maker.sh
+++ b/isoimage/maker.sh
@@ -20,7 +20,7 @@ mount -v -t vfat -o sync /dev/mapper/loop0p1 sdcard/boot
 echo root:root | chroot sdcard chpasswd
 chroot sdcard apt update
 chroot sdcard apt install -y build-essential python-dev python-pip cython python-smbus python-numpy python-rpi.gpio python-serial portaudio19-dev alsa-utils git libportaudio2 libffi-dev raspberrypi-kernel ntpdate
-chroot sdcard pip install rtmidi-python pyaudio cffi sounddevice
+chroot sdcard pip install python-rtmidi pyaudio cffi sounddevice
 chroot sdcard sh -c "cd /root ; git clone https://github.com/josephernest/SamplerBox.git ; cd SamplerBox ; python setup.py build_ext --inplace"
 cp -R root/* sdcard
 chroot sdcard systemctl enable /etc/systemd/system/samplerbox.service

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -67,9 +67,9 @@ class waveread(wave.Wave_read):
         self._loops = []
         self._ieee = False
         self._file = Chunk(file, bigendian=0)
-        if self._file.getname() != 'RIFF':
+        if self._file.getname() != b'RIFF':
             raise OSError('file does not start with RIFF id')
-        if self._file.read(4) != 'WAVE':
+        if self._file.read(4) != b'WAVE':
             raise OSError('not a WAVE file')
         self._fmt_chunk_read = 0
         self._data_chunk = None
@@ -80,21 +80,21 @@ class waveread(wave.Wave_read):
             except EOFError:
                 break
             chunkname = chunk.getname()
-            if chunkname == 'fmt ':
+            if chunkname == b'fmt ':
                 self._read_fmt_chunk(chunk)
                 self._fmt_chunk_read = 1
-            elif chunkname == 'data':
+            elif chunkname == b'data':
                 if not self._fmt_chunk_read:
                     raise OSError('data chunk before fmt chunk')
                 self._data_chunk = chunk
                 self._nframes = chunk.chunksize // self._framesize
                 self._data_seek_needed = 0
-            elif chunkname == 'cue ':
+            elif chunkname == b'cue ':
                 numcue = struct.unpack('<i', chunk.read(4))[0]
                 for i in range(numcue):
                     id, position, datachunkid, chunkstart, blockstart, sampleoffset = struct.unpack('<iiiiii', chunk.read(24))
                     self._cue.append(sampleoffset)
-            elif chunkname == 'smpl':
+            elif chunkname == b'smpl':
                 manuf, prod, sampleperiod, midiunitynote, midipitchfraction, smptefmt, smpteoffs, numsampleloops, samplerdata = struct.unpack(
                     '<iiiiiiiii', chunk.read(36))
                 for i in range(numsampleloops):

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -36,7 +36,7 @@ import sounddevice
 import threading
 from chunk import Chunk
 import struct
-import rtmidi_python as rtmidi
+import rtmidi
 import samplerbox_audio
 
 
@@ -481,11 +481,11 @@ if USE_SYSTEMLED:
 midi_in = [rtmidi.MidiIn()]
 previous = []
 while True:
-    for port in midi_in[0].ports:
+    for port in midi_in[0].get_ports():
         if port not in previous and 'Midi Through' not in port:
             midi_in.append(rtmidi.MidiIn())
             midi_in[-1].callback = MidiCallback
             midi_in[-1].open_port(port)
             print 'Opened MIDI: ' + port
-    previous = midi_in[0].ports
+    previous = midi_in[0].get_ports()
     time.sleep(2)

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -162,7 +162,7 @@ class Sound:
         if sampwidth == 2:
             npdata = numpy.fromstring(data, dtype=numpy.int16)
         elif sampwidth == 3:
-            npdata = samplerbox_audio.binary24_to_int16(data, len(data)/3)
+            npdata = samplerbox_audio.binary24_to_int16(data, len(data)//3)
         if numchan == 1:
             npdata = numpy.repeat(npdata, 2)
         return npdata

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -68,9 +68,9 @@ class waveread(wave.Wave_read):
         self._ieee = False
         self._file = Chunk(file, bigendian=0)
         if self._file.getname() != 'RIFF':
-            raise Error, 'file does not start with RIFF id'
+            raise OSError('file does not start with RIFF id')
         if self._file.read(4) != 'WAVE':
-            raise Error, 'not a WAVE file'
+            raise OSError('not a WAVE file')
         self._fmt_chunk_read = 0
         self._data_chunk = None
         while 1:
@@ -85,7 +85,7 @@ class waveread(wave.Wave_read):
                 self._fmt_chunk_read = 1
             elif chunkname == 'data':
                 if not self._fmt_chunk_read:
-                    raise Error, 'data chunk before fmt chunk'
+                    raise OSError('data chunk before fmt chunk')
                 self._data_chunk = chunk
                 self._nframes = chunk.chunksize // self._framesize
                 self._data_seek_needed = 0
@@ -102,7 +102,7 @@ class waveread(wave.Wave_read):
                     self._loops.append([start, end])
             chunk.skip()
         if not self._fmt_chunk_read or not self._data_chunk:
-            raise Error, 'fmt chunk and/or data chunk missing'
+            raise OSError('fmt chunk and/or data chunk missing')
 
     def getmarkers(self):
         return self._cue

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -334,18 +334,18 @@ def ActuallyLoad():
                 samples[midinote, 127] = Sound(file, midinote, 127)
 
     initial_keys = set(samples.keys())
-    for midinote in xrange(128):
+    for midinote in range(128):
         lastvelocity = None
-        for velocity in xrange(128):
+        for velocity in range(128):
             if (midinote, velocity) not in initial_keys:
                 samples[midinote, velocity] = lastvelocity
             else:
                 if not lastvelocity:
-                    for v in xrange(velocity):
+                    for v in range(velocity):
                         samples[midinote, v] = samples[midinote, velocity]
                 lastvelocity = samples[midinote, velocity]
         if not lastvelocity:
-            for velocity in xrange(128):
+            for velocity in range(128):
                 try:
                     samples[midinote, velocity] = samples[midinote-1, velocity]
                 except:

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -308,8 +308,8 @@ def ActuallyLoad():
                         defaultparams.update(dict([item.split('=') for item in pattern.split(',', 1)[1].replace(' ', '').replace('%', '').split(',')]))
                     pattern = pattern.split(',')[0]
                     pattern = re.escape(pattern.strip())
-                    pattern = pattern.replace(r"\%midinote", r"(?P<midinote>\d+)").replace(r"\%velocity", r"(?P<velocity>\d+)")\
-                                     .replace(r"\%notename", r"(?P<notename>[A-Ga-g]#?[0-9])").replace(r"\*", r".*?").strip()    # .*? => non greedy
+                    pattern = pattern.replace(r"%midinote", r"(?P<midinote>\d+)").replace(r"%velocity", r"(?P<velocity>\d+)")\
+                                     .replace(r"%notename", r"(?P<notename>[A-Ga-g]#?[0-9])").replace(r"\*", r".*?").strip()    # .*? => non greedy
                     for fname in os.listdir(dirname):
                         if LoadingInterrupt:
                             return

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -463,6 +463,7 @@ if USE_SERIALPORT_MIDI:
                 if i == 2 and message[0] >> 4 == 12:  # program change: don't wait for a third byte: it has only 2 bytes
                     message[2] = 0
                     i = 3
+            logging.debug('midi: {}'.format(message))
             MidiCallback(message, None)
 
     MidiThread = threading.Thread(target=MidiSerialCallback)


### PR DESCRIPTION
This pull requests includes various changes that I couldn't easily split into individual pull requests as they would conflict with each other, but I would be more than happy to isolate some changes out and remove others.

The changes currently include
* switching to `python-rtmidi` (covered by #43)
* allow configuration of multiple serial ports (I found that useful when receiving MIDI messages over USB; RPi sometimes mounts the USB to 0 and sometimes to 1, for example; it might also be useful on Windows where COM ports get assigned semi-randomly)
* introduce proper logging (that can easily be redirected to a file instead of just stdout), also log midi messages being received
* make the code compatible with python 3

What's still missing:
* updated README and image building script to actually switch to python 3 (not too important, the code works with python 2.7 anyway)
* I'm not sure about some of the replacements patterns (the existing ones don't work for me in Python 3)
* I would like to read settings from a config file and/or command-line parameters rather than having to modify the script itself
* basic error handling for cases when the ALSA library fails

What I'm puzzled about: 
* The source code says "`see hack in /boot/cmline.txt: 38400 is 31250 baud for MIDI!`", but there's no `/boot/cmline.txt` anywhere and the baud rate was in fact 38400, not 31250 as claimed. Since we control the midi source, we just switched the baud rate to 115200 on both sides. When sending MIDI messages at 31250 we had tons of strange issues, with midi messaged being misinterpreted at times (while working at other times).