### PR TITLE
Switch rtmidi wrapper from from rtmidi-python to python-rtmidi

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommende
 
 You can use a ready-to-use ISO image from the [Releases](https://github.com/josephernest/SamplerBox/releases) page or do a manual install:
 
-0. Start with a standard RaspiOS intsall. The following steps have been tested with [2021-05-07-raspios-buster-armhf-lite.zip](https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-05-28/2021-05-07-raspios-buster-armhf-lite.zip).
+0. Start with a standard RaspiOS intsall. The following steps have been tested with ADD NEW VERSION HERE!!! [2021-05-07-raspios-buster-armhf-lite.zip](https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-05-28/2021-05-07-raspios-buster-armhf-lite.zip).
 
-1. Install the required dependencies (Python-related packages and audio libraries - the current version requires at least Python 3.7):
+1. Install the required dependencies (Python-related packages and audio libraries - the current version required specifically Python 3.7 as rtmidi-python uses code which was removed in python 3.8):
 
     ~~~
     sudo apt update
-    sudo apt -y install git python3-pip python3-smbus python3-numpy libportaudio2 
+    sudo apt -y install git python3-pip python3-smbus python3-numpy libportaudio2 libasound2-dev
     sudo apt -y install raspberrypi-kernel  # quite long to install, do it only if necessary, it solves a "no sound before 25 second on boot" problem
-    sudo pip3 install cython rtmidi-python cffi sounddevice pyserial
+    sudo pip3 install cython python-rtmidi cffi sounddevice pyserial
     ~~~
     
 2. Download SamplerBox and build it with:

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -23,7 +23,7 @@ import sounddevice
 import threading
 from chunk import Chunk
 import struct
-import rtmidi_python as rtmidi
+import rtmidi
 import samplerbox_audio
 
 #########################################
@@ -424,14 +424,29 @@ if USE_SYSTEMLED:
 # MAIN LOOP
 #########################################
 
-midi_in = [rtmidi.MidiIn(b'in')]
-previous = []
-while True:
-    for port in midi_in[0].ports:
-        if port not in previous and b'Midi Through' not in port:
-            midi_in.append(rtmidi.MidiIn(b'in'))
-            midi_in[-1].callback = MidiCallback
-            midi_in[-1].open_port(port)
-            print('Opened MIDI: ' + str(port))
-    previous = midi_in[0].ports
-    time.sleep(2)
+midiin = rtmidi.MidiIn()
+
+if midiin.get_current_api() == rtmidi.API_UNIX_JACK:
+    print("Using JACK API for MIDI input.")
+
+if midiin.get_current_api() == rtmidi.API_LINUX_ALSA:
+    print("Using ALSA API for MIDI input.")
+
+ports = midiin.get_port_count()
+print('MIDI Port count: ' + str(ports))
+
+# collect all devices which are found
+# previous = []
+
+midiin.set_callback = MidiCallback
+midiin.open_port(0)
+print('Opened MIDI: ' + str(midiin.get_port_name(0)))
+# while True:
+    # for port in midi_in[0].ports:
+        # if port not in previous and b'Midi Through' not in port:
+            # midi_in.append(rtmidi.MidiIn(b'in'))
+            # midi_in[-1].callback = MidiCallback
+            # midi_in[-1].open_port(port)
+            # print('Opened MIDI: ' + str(port))
+    # previous = midi_in[0].ports
+    # time.sleep(2)

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -424,32 +424,24 @@ if USE_SYSTEMLED:
 # MAIN LOOP
 #########################################
 
-midiin = rtmidi.MidiIn()
-
-if midiin.get_current_api() == rtmidi.API_UNIX_JACK:
-    print("Using JACK API for MIDI input.")
+midiin = [rtmidi.MidiIn(name=b'rtmidi in')]
 
 if midiin.get_current_api() == rtmidi.API_LINUX_ALSA:
     print("Using ALSA API for MIDI input.")
+else:
+    print("NOT using ALSA API for MIDI input!")
 
-ports = midiin.get_port_count()
-print('MIDI Port count: ' + str(ports))
+print('MIDI Port count: ' + str(midiin.get_port_count()))
 
-# collect all devices which are found
-# previous = []
-
-midiin.set_callback(MidiCallback)
-midiin.open_port(0)
-print('Opened MIDI: ' + str(midiin.get_port_name(0)))
+# collect all available device port numbers
+previous = []
 
 while True:
+    for port, name in enumerate(midiin.get_ports()):
+        if port not in previous and b'Midi Through' not in name:
+            midiin.append(rtmidi.MidiIn(name=b'rtmidi in'))
+            midiin[-1].set_callback(MidiCallback)
+            midiin[-1].open_port(port)
+            print('Opened MIDI ' + str(name) + ' on port ' + str(port))
+    previous = range(midiin.get_port_count()-1)
     time.sleep(2)
-# while True:
-    # for port in midi_in[0].ports:
-        # if port not in previous and b'Midi Through' not in port:
-            # midi_in.append(rtmidi.MidiIn(b'in'))
-            # midi_in[-1].callback = MidiCallback
-            # midi_in[-1].open_port(port)
-            # print('Opened MIDI: ' + str(port))
-    # previous = midi_in[0].ports
-    # time.sleep(2)

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -438,9 +438,12 @@ print('MIDI Port count: ' + str(ports))
 # collect all devices which are found
 # previous = []
 
-midiin.set_callback = MidiCallback
+midiin.set_callback(MidiCallback)
 midiin.open_port(0)
 print('Opened MIDI: ' + str(midiin.get_port_name(0)))
+
+while True:
+    time.sleep(2)
 # while True:
     # for port in midi_in[0].ports:
         # if port not in previous and b'Midi Through' not in port:

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -426,7 +426,7 @@ if USE_SYSTEMLED:
 
 midiin = [rtmidi.MidiIn(name=b'rtmidi in')]
 
-if midiin[1].get_current_api() == rtmidi.API_LINUX_ALSA:
+if midiin[0].get_current_api() == rtmidi.API_LINUX_ALSA:
     print("Using ALSA API for MIDI input.")
 else:
     print("NOT using ALSA API for MIDI input!")
@@ -437,11 +437,11 @@ print('MIDI Port count: ' + str(midiin.get_port_count()))
 previous = []
 
 while True:
-    for port, name in enumerate(midiin[1].get_ports()):
+    for port, name in enumerate(midiin[0].get_ports()):
         if port not in previous and b'Midi Through' not in name:
             midiin.append(rtmidi.MidiIn(name=b'rtmidi in'))
             midiin[-1].set_callback(MidiCallback)
             midiin[-1].open_port(port)
             print('Opened MIDI ' + str(name) + ' on port ' + str(port))
-    previous = range(midiin[1].get_port_count()-1)
+    previous = range(midiin[0].get_port_count()-1)
     time.sleep(2)

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -431,14 +431,14 @@ if midiin[0].get_current_api() == rtmidi.API_LINUX_ALSA:
 else:
     print("NOT using ALSA API for MIDI input!")
 
-print('MIDI Port count: ' + str(midiin.get_port_count()))
+print('MIDI Port count: ' + str(midiin[0].get_port_count()))
 
 # collect all available device port numbers
 previous = []
 
 while True:
     for port, name in enumerate(midiin[0].get_ports()):
-        if port not in previous and b'Midi Through' not in name:
+        if port not in previous and "Midi Through" not in name:
             midiin.append(rtmidi.MidiIn(name=b'rtmidi in'))
             midiin[-1].set_callback(MidiCallback)
             midiin[-1].open_port(port)

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -426,7 +426,7 @@ if USE_SYSTEMLED:
 
 midiin = [rtmidi.MidiIn(name=b'rtmidi in')]
 
-if midiin.get_current_api() == rtmidi.API_LINUX_ALSA:
+if midiin[1].get_current_api() == rtmidi.API_LINUX_ALSA:
     print("Using ALSA API for MIDI input.")
 else:
     print("NOT using ALSA API for MIDI input!")
@@ -437,11 +437,11 @@ print('MIDI Port count: ' + str(midiin.get_port_count()))
 previous = []
 
 while True:
-    for port, name in enumerate(midiin.get_ports()):
+    for port, name in enumerate(midiin[1].get_ports()):
         if port not in previous and b'Midi Through' not in name:
             midiin.append(rtmidi.MidiIn(name=b'rtmidi in'))
             midiin[-1].set_callback(MidiCallback)
             midiin[-1].open_port(port)
             print('Opened MIDI ' + str(name) + ' on port ' + str(port))
-    previous = range(midiin.get_port_count()-1)
+    previous = range(midiin[1].get_port_count()-1)
     time.sleep(2)


### PR DESCRIPTION
The latest raspi image (bullseye) comes with python 3.9.2., but the (not maintained) rtmidi-python package requires python3.7 or less due to deprecation of tp_print. This leads to error messages during installation:
` ‘PyTypeObject’ {aka ‘struct _typeobject’} has no member named ‘tp_print’`

Out of the box,  libasound2-dev was not installed and has to be installed manually.

With the modifications proposed, SampleBox runs fine on a RaspberryPi 2 with RaspiOS 11 lite (2022-09-06)

This is my very first pull request ever, so if I did anything wrong, pease give me feedback on how to improve.