### PR TITLE
Make serial port settings configurable

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,3 +10,5 @@ USE_BUTTONS = False                     # Set to True to use momentary buttons (
 USE_I2C_7SEGMENTDISPLAY = False         # Set to True to use a 7-segment display via I2C
 USE_SERIALPORT_MIDI = False             # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
 USE_SYSTEMLED = False                   # Flashing LED after successful boot, only works on RPi/Linux
+SERIALPORT_PORT = '/dev/ttyAMA0'
+SERIALPORT_BAUDRATE = 31250

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -384,7 +384,7 @@ else:
 
 if USE_SERIALPORT_MIDI:
     import serial
-    ser = serial.Serial('/dev/ttyAMA0', baudrate=31250)
+    ser = serial.Serial(SERIALPORT_PORT, baudrate=SERIALPORT_BAUDRATE)
     def MidiSerialCallback():
         message = [0, 0, 0]
         while True:


### PR DESCRIPTION
This minimal change allows a cleaner way to change the port and baud rate when the needs are slightly different.

In particular, this helps a lot under Windows where there's no `/dev/ttyAMA0` port, for example.