### PR TITLE
Use variables for iso image creation

### DIFF
--- a/isoimage/maker.sh
+++ b/isoimage/maker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -v
 # The script takes a standard RaspiOS Lite image, installs SamplerBox on it, and creates a ready-to-use image.
-# Notes: 
+# Notes:
 # * this script works on Pi4 but not on Pi2 - tested 2022-08-09
 # * the process is quite long, 1 hr 40 min on a Pi4 - for this reason, I usually start it from screen (screen -S maker, sudo ./maker.sh, CTRL A D to detach)
 #

--- a/isoimage/maker.sh
+++ b/isoimage/maker.sh
@@ -7,11 +7,19 @@
 # SamplerBox (https://www.samplerbox.org)
 # License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0) (https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
+export RASPIOS_ARCH=armhf
+export RASPIOS_NAME=buster
+export RASPIOS_DATE_IMG=2021-05-07
+export RASPIOS_DATE_DIR=2021-05-28
+
+export RASPIOS_BASENAME="${RASPIOS_DATE_IMG}-raspios-${RASPIOS_NAME}-${RASPIOS_ARCH}-lite"
+export RASPIOS_URL="https://downloads.raspberrypi.org/raspios_lite_${RASPIOS_ARCH}/images/raspios_lite_${RASPIOS_ARCH}-${RASPIOS_DATE_DIR}/${RASPIOS_BASENAME}.zip"
+
 set -e  # exit immediately if a command exits with a non-zero status
 apt install -y kpartx parted zip
-[ ! -f "2021-05-07-raspios-buster-armhf-lite.zip" ] && wget https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-05-28/2021-05-07-raspios-buster-armhf-lite.zip
-[ ! -f "2021-05-07-raspios-buster-armhf-lite.img" ] && unzip 2021-05-07-raspios-buster-armhf-lite.zip
-cp 2021-05-07-raspios-buster-armhf-lite.img sb.img
+[ ! -f "${RASPIOS_BASENAME}.zip" ] && wget "${RASPIOS_URL}"
+[ ! -f "${RASPIOS_BASENAME}.img" ] && unzip "${RASPIOS_BASENAME}.zip"
+cp "${RASPIOS_BASENAME}.img" sb.img
 truncate -s 2500M sb.img      # M=1024*1024
 kpartx -av sb.img
 parted -m /dev/loop0 resizepart 2 2499MiB  # MiB=1024*1024

--- a/isoimage/maker.sh
+++ b/isoimage/maker.sh
@@ -1,25 +1,21 @@
 #!/bin/bash -v
 # The script takes a standard RaspiOS Lite image, installs SamplerBox on it, and creates a ready-to-use image.
-# Notes:
+# Notes: 
 # * this script works on Pi4 but not on Pi2 - tested 2022-08-09
 # * the process is quite long, 1 hr 40 min on a Pi4 - for this reason, I usually start it from screen (screen -S maker, sudo ./maker.sh, CTRL A D to detach)
 #
 # SamplerBox (https://www.samplerbox.org)
 # License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0) (https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
-export RASPIOS_ARCH=armhf
-export RASPIOS_NAME=buster
-export RASPIOS_DATE_IMG=2021-05-07
-export RASPIOS_DATE_DIR=2021-05-28
-
-export RASPIOS_BASENAME="${RASPIOS_DATE_IMG}-raspios-${RASPIOS_NAME}-${RASPIOS_ARCH}-lite"
-export RASPIOS_URL="https://downloads.raspberrypi.org/raspios_lite_${RASPIOS_ARCH}/images/raspios_lite_${RASPIOS_ARCH}-${RASPIOS_DATE_DIR}/${RASPIOS_BASENAME}.zip"
+export RASPIOS_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-05-28/2021-05-07-raspios-buster-armhf-lite.zip"
+export RASPIOS_COMPRESSED="2021-05-07-raspios-buster-armhf-lite.zip"
+export RASPIOS_IMG="2021-05-07-raspios-buster-armhf-lite.img"
 
 set -e  # exit immediately if a command exits with a non-zero status
 apt install -y kpartx parted zip
-[ ! -f "${RASPIOS_BASENAME}.zip" ] && wget "${RASPIOS_URL}"
-[ ! -f "${RASPIOS_BASENAME}.img" ] && unzip "${RASPIOS_BASENAME}.zip"
-cp "${RASPIOS_BASENAME}.img" sb.img
+[ ! -f "${RASPIOS_COMPRESSED}" ] && wget "${RASPIOS_URL}"
+[ ! -f "${RASPIOS_IMG}" ] && unzip "${RASPIOS_COMPRESSED}"
+cp "${RASPIOS_IMG}" sb.img
 truncate -s 2500M sb.img      # M=1024*1024
 kpartx -av sb.img
 parted -m /dev/loop0 resizepart 2 2499MiB  # MiB=1024*1024


### PR DESCRIPTION
Rationale for this change:

I wanted to create a 64-bit image using a VM inside macOS running on a M1 chip (the image creation is super fast compared to the timings cited in your `README`), and I wanted to use the latest RaspiOS for that.
In order to do that I needed to use a different image, but changing the gazillion of repetitive names is super error prone.

This minor change makes it much easier to switch to a different architecture and different OS version (that is: it requires a lot less changes).

Without the last compression step and using `arm64`, `bullseye`, `2022-09-22`, `2022-09-26` , the script needs 2,5 minutes to complete on the oldest & cheapest mac mini with M1.