### PR TITLE
Add support for python-rtmidi

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Website: [www.samplerbox.org](https://www.samplerbox.org)
 
 # Install
 
-SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommended to use a USB DAC (PCM2704 USB DAC for less than 10€ on eBay is fine) for better sound quality. 
+SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommended to use a USB DAC (PCM2704 USB DAC for less than 10€ on eBay is fine) for better sound quality.
 
 You can use a ready-to-use ISO image from the [Releases](https://github.com/josephernest/SamplerBox/releases) page or do a manual install:
 
@@ -22,12 +22,22 @@ You can use a ready-to-use ISO image from the [Releases](https://github.com/jose
 
     ~~~
     sudo apt update
-    sudo apt -y install git python3-pip python3-smbus python3-numpy libportaudio2 
+    sudo apt -y install git python3-pip python3-smbus python3-numpy libportaudio2 libasound2-dev
     sudo apt -y install raspberrypi-kernel  # quite long to install, do it only if necessary, it solves a "no sound before 25 second on boot" problem
-    sudo pip3 install cython rtmidi-python cffi sounddevice pyserial
+    sudo pip3 install cython cffi sounddevice pyserial
     ~~~
-    
-2. Download SamplerBox and build it with:
+
+    For python < 3.9
+    ~~~
+    sudo pip3 install rtmidi-python
+    ~~~
+
+    For python >= 3.9
+    ~~~
+    sudo pip3 install python-rtmidi
+    ~~~
+
+1. Download SamplerBox and build it with:
 
     ~~~
     git clone https://github.com/josephernest/SamplerBox.git
@@ -35,15 +45,15 @@ You can use a ready-to-use ISO image from the [Releases](https://github.com/jose
     sudo python3 setup.py build_ext --inplace
     ~~~
 
-3. Reboot the Pi, and run the soft with: 
-    
+1. Reboot the Pi, and run the soft with:
+
     ~~~
     sudo python3 samplerbox.py
     ~~~
 
     Play some notes on the connected MIDI keyboard, you'll hear some sound!
 
-4. *(Optional)*  Modify `config.py` if you want to change root directory for sample-sets, default soundcard, etc.
+1. *(Optional)*  Modify `config.py` if you want to change root directory for sample-sets, default soundcard, etc.
 
 
 # How to use it


### PR DESCRIPTION
There seems to be quite some interest (and also confusion) from the community about using up to date rpi images and [python 3.9](https://endoflife.date/python) :

* https://github.com/josephernest/SamplerBox/issues/58
* https://github.com/josephernest/SamplerBox/issues/59
* https://github.com/josephernest/SamplerBox/pull/54
* https://github.com/josephernest/SamplerBox/pull/43

This PR adds the possibility to use `python-rtmidi` while keeping backwards compatibility to `rtmidi-python`

The apt package libasound2-dev is an additional requirement

Thanks to @theredled for the [code snippet](https://github.com/josephernest/SamplerBox/issues/58#issuecomment-1822589705)

Due to the lack of a midi keyboard / input device I used the following code to test on a raspberry pi 1 with Python 3.9.2

```
import time
import rtmidi

midiout = rtmidi.MidiOut()
midiout.open_virtual_port("My virtual output")
time.sleep(2)
note_on = [0x90, 60, 112] # channel 1, middle C, velocity 112
note_off = [0x80, 60, 0]
midiout.send_message(note_on)
time.sleep(1)
midiout.send_message(note_off)
```
Works nicely!

Also tested on debian bookworm (Python 3.11.2) x86-64

To better handle the distinction between 'old' and 'new' python versions I created a follow up PR https://github.com/josephernest/SamplerBox/pull/63