### PR TITLE
Make it pip installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Website: [www.samplerbox.org](https://www.samplerbox.org)
 
 # Install
 
-SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommended to use a USB DAC (PCM2704 USB DAC for less than 10€ on eBay is fine) for better sound quality. 
+SamplerBox works with the RaspberryPi's built-in soundcard, but it is recommended to use a USB DAC (PCM2704 USB DAC for less than 10€ on eBay is fine) for better sound quality.
 
 You can use a ready-to-use ISO image from the [Releases](https://github.com/josephernest/SamplerBox/releases) page or do a manual install:
 
@@ -22,28 +22,26 @@ You can use a ready-to-use ISO image from the [Releases](https://github.com/jose
 
     ~~~
     sudo apt update
-    sudo apt -y install git python3-pip python3-smbus python3-numpy libportaudio2 
+    sudo apt -y install git python3-pip libportaudio2 libopenblas-dev
     sudo apt -y install raspberrypi-kernel  # quite long to install, do it only if necessary, it solves a "no sound before 25 second on boot" problem
-    sudo pip3 install cython rtmidi-python cffi sounddevice pyserial
     ~~~
-    
-2. Download SamplerBox and build it with:
 
+1. Download SamplerBox and build it with:
     ~~~
     git clone https://github.com/josephernest/SamplerBox.git
     cd SamplerBox
-    sudo python3 setup.py build_ext --inplace
+    sudo python3 -m pip install .
     ~~~
 
-3. Reboot the Pi, and run the soft with: 
-    
+1. Reboot the Pi, and run the soft with:
+
     ~~~
     sudo python3 samplerbox.py
     ~~~
 
     Play some notes on the connected MIDI keyboard, you'll hear some sound!
 
-4. *(Optional)*  Modify `config.py` if you want to change root directory for sample-sets, default soundcard, etc.
+1. *(Optional)*  Modify `config.py` if you want to change root directory for sample-sets, default soundcard, etc.
 
 
 # How to use it

--- a/isoimage/maker.sh
+++ b/isoimage/maker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -v
 # The script takes a standard RaspiOS Lite image, installs SamplerBox on it, and creates a ready-to-use image.
-# Notes: 
+# Notes:
 # * this script works on Pi4 but not on Pi2 - tested 2022-08-09
 # * the process is quite long, 1 hr 40 min on a Pi4 - for this reason, I usually start it from screen (screen -S maker, sudo ./maker.sh, CTRL A D to detach)
 #
@@ -22,9 +22,8 @@ mount -v -t ext4 -o sync /dev/mapper/loop0p2 sdcard
 mount -v -t vfat -o sync /dev/mapper/loop0p1 sdcard/boot
 echo root:root | chroot sdcard chpasswd
 chroot sdcard apt update
-chroot sdcard apt -y install git python3-pip python3-smbus python3-numpy libportaudio2 raspberrypi-kernel ntpdate
-chroot sdcard pip3 install cython rtmidi-python cffi sounddevice pyserial
-chroot sdcard sh -c "cd /root ; git clone https://github.com/josephernest/SamplerBox.git ; cd SamplerBox ; python3 setup.py build_ext --inplace"
+chroot sdcard apt -y install git python3-pip libportaudio2 raspberrypi-kernel ntpdate libasound2-dev libopenblas-dev
+chroot sdcard sh -c "cd /root ; git clone https://github.com/josephernest/SamplerBox.git ; cd SamplerBox ; python3 -m pip install ."
 cp -R root/* sdcard
 chroot sdcard chmod +x /root/usb-mount.sh
 chroot sdcard systemctl enable /etc/systemd/system/samplerbox.service

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,33 @@
-from distutils.core import setup
-from Cython.Build import cythonize
-import numpy
+from setuptools import setup, Extension
 
-setup(ext_modules = cythonize("samplerbox_audio.pyx"), include_dirs=[numpy.get_include()])
+
+def my_build_ext(pars):
+    from setuptools.command.build_ext import build_ext as _build_ext
+
+    class build_ext(_build_ext):
+        def finalize_options(self):
+            _build_ext.finalize_options(self)
+            __builtins__.__NUMPY_SETUP__ = False
+            import numpy
+            self.include_dirs.append(numpy.get_include())
+
+    return build_ext(pars)
+
+
+setup(ext_modules=[Extension(name="samplerbox_audio",
+                             sources=["samplerbox_audio.pyx"])],
+      cmdclass={'build_ext': my_build_ext},
+      setup_requires=[
+          "cython",
+          "numpy"
+      ],
+      install_requires=[
+          'cffi',
+          'numpy',
+          'pyserial',
+          'python-rtmidi; python_version >= "3.9"',
+          'rtmidi-python; python_version < "3.9"',
+          'smbus',
+          'sounddevice',
+      ],
+      )


### PR DESCRIPTION
The python dependencies are now defined in the package itself. This makes it possible to conditionally install dependencies based on python versions. Furthermore this makes it possible to install it as a pip package from [pypi](https://pypi.org/project/SamplerBox/)

## Tested on 
* raspberrpy pi 1 Raspbian GNU/Linux 11 (bullseye)
* x86-64 Debian GNU/Linux 12 (bookworm)

This should not be merged before https://github.com/josephernest/SamplerBox/pull/62