### PR TITLE
Support volume control and pitchbend, and ignore MIDI devices

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,11 +4,13 @@
 #########################################
 
 AUDIO_DEVICE_ID = 2                     # change this number to use another soundcard
-SAMPLES_DIR = "/media/"                 # The root directory containing the sample-sets. Example: "/media/" to look for samples on a USB stick / SD card
+SAMPLES_DIR = "."                       # The root directory containing the sample-sets. Example: "/media/" to look for samples on a USB stick / SD card
 MAX_POLYPHONY = 80                      # This can be set higher, but 80 is a safe value
-USE_BUTTONS = False                      # Set to True to use momentary buttons (connected to RaspberryPi's GPIO pins) to change preset
-USE_I2C_7SEGMENTDISPLAY = False          # Set to True to use a 7-segment display via I2C
-USE_SERIALPORT_MIDI = False              # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
+USE_BUTTONS = False                     # Set to True to use momentary buttons (connected to RaspberryPi's GPIO pins) to change preset
+USE_I2C_7SEGMENTDISPLAY = False         # Set to True to use a 7-segment display via I2C
+USE_SERIALPORT_MIDI = False             # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
 USE_SYSTEMLED = False                   # Flashing LED after successful boot, only works on RPi/Linux
+SERIALPORT_PORT = '/dev/ttyAMA0'
+SERIALPORT_BAUDRATE = 31250
 PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
 

--- a/config.py
+++ b/config.py
@@ -4,11 +4,11 @@
 #########################################
 
 AUDIO_DEVICE_ID = 2                     # change this number to use another soundcard
-SAMPLES_DIR = "."                       # The root directory containing the sample-sets. Example: "/media/" to look for samples on a USB stick / SD card
+SAMPLES_DIR = "/media/"                 # The root directory containing the sample-sets. Example: "/media/" to look for samples on a USB stick / SD card
 MAX_POLYPHONY = 80                      # This can be set higher, but 80 is a safe value
-USE_BUTTONS = False                     # Set to True to use momentary buttons (connected to RaspberryPi's GPIO pins) to change preset
-USE_I2C_7SEGMENTDISPLAY = False         # Set to True to use a 7-segment display via I2C
-USE_SERIALPORT_MIDI = False             # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
+USE_BUTTONS = False                      # Set to True to use momentary buttons (connected to RaspberryPi's GPIO pins) to change preset
+USE_I2C_7SEGMENTDISPLAY = False          # Set to True to use a 7-segment display via I2C
+USE_SERIALPORT_MIDI = False              # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
 USE_SYSTEMLED = False                   # Flashing LED after successful boot, only works on RPi/Linux
-SERIALPORT_PORT = '/dev/ttyAMA0'
-SERIALPORT_BAUDRATE = 31250
+PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
+

--- a/config.py
+++ b/config.py
@@ -13,5 +13,5 @@ USE_SYSTEMLED = False                   # Flashing LED after successful boot, on
 SERIALPORT_PORT = '/dev/ttyAMA0'
 SERIALPORT_BAUDRATE = 31250
 PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
-IGNORE_MIDI_DEVICES =  [b'Impulse 20:1', b'Impulse 20:2']
+IGNORE_MIDI_DEVICES =  []               # Ignore MIDI devices to avoid midi errors and missing/lingering notes. For example: [b'Impulse 20:1', b'Impulse 20:2']
 

--- a/config.py
+++ b/config.py
@@ -13,4 +13,5 @@ USE_SYSTEMLED = False                   # Flashing LED after successful boot, on
 SERIALPORT_PORT = '/dev/ttyAMA0'
 SERIALPORT_BAUDRATE = 31250
 PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
+IGNORE_MIDI_DEVICES =  [b'Impulse 20:1', b'Impulse 20:2']
 

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -441,7 +441,7 @@ midi_in = [rtmidi.MidiIn(b'in')]
 previous = []
 while True:
     for port in midi_in[0].ports:
-        if port not in previous and b'Midi Through' not in port:
+        if port not in IGNORE_MIDI_DEVICES and port not in previous and b'Midi Through' not in port:
             midi_in.append(rtmidi.MidiIn(b'in'))
             midi_in[-1].callback = MidiCallback
             midi_in[-1].open_port(port)

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -147,7 +147,7 @@ sustainplayingnotes = []
 sustain = False
 playingsounds = []
 globalvolume = globalsoundvolume = DEFAULT_VOLUME = 10 ** (-12.0/20)  # -12dB default global volume
-globalvolumeknob = 64
+globalvolumeknob = 127
 globaltranspose = 0
 pitchbend = 0
 

--- a/samplerbox_audio.pyx
+++ b/samplerbox_audio.pyx
@@ -61,17 +61,17 @@ def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndar
         else:
             ii = 0            
             for i in range(N):
-                j = pos + ii * speed 
+                j = pos + ii * speed
                 ii += 1                  
                 k = <int> j
                 if k > length - 2:
                     pos = looppos + 1
                     snd.pos = pos
                     ii = 0
-                    j = pos + ii * speed  
+                    j = pos + ii * speed
                     k = <int> j  
                 bb[2 * i] += zz[2 * k] + (j - k) * (zz[2 * k + 2] - zz[2 * k])                                               # linear interpolation
-                bb[2 * i + 1] += zz[2 * k + 1] + (j - k) * (zz[2 * k + 3] - zz[2 * k + 1]) 
+                bb[2 * i + 1] += zz[2 * k + 1] + (j - k) * (zz[2 * k + 3] - zz[2 * k + 1])
 
         snd.pos += ii * speed
 

--- a/samplerbox_audio.pyx
+++ b/samplerbox_audio.pyx
@@ -14,7 +14,7 @@ import cython
 import numpy
 cimport numpy
 
-def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndarray FADEOUT, int FADEOUTLENGTH, numpy.ndarray SPEED):
+def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndarray FADEOUT, int FADEOUTLENGTH, numpy.ndarray SPEED, pitchbend, pitchbandnoterange):
     cdef int i, ii, k, l, N, length, looppos, fadeoutpos
     cdef float speed, newsz, pos, j
     cdef numpy.ndarray b = numpy.zeros(2 * frame_count, numpy.float32)      # output buffer
@@ -29,7 +29,8 @@ def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndar
         looppos = snd.sound.loop
         length = snd.sound.nframes
         speed = SPEED[snd.note - snd.sound.midinote]
-        newsz = frame_count * speed
+        speed += (SPEED[snd.note - snd.sound.midinote + pitchbandnoterange] - speed) * pitchbend / 64
+        newsz = frame_count * speed 
         z = snd.sound.data
         zz = <short *> (z.data)
 
@@ -60,17 +61,17 @@ def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndar
         else:
             ii = 0            
             for i in range(N):
-                j = pos + ii * speed
+                j = pos + ii * speed 
                 ii += 1                  
                 k = <int> j
                 if k > length - 2:
                     pos = looppos + 1
                     snd.pos = pos
                     ii = 0
-                    j = pos + ii * speed   
+                    j = pos + ii * speed  
                     k = <int> j  
                 bb[2 * i] += zz[2 * k] + (j - k) * (zz[2 * k + 2] - zz[2 * k])                                               # linear interpolation
-                bb[2 * i + 1] += zz[2 * k + 1] + (j - k) * (zz[2 * k + 3] - zz[2 * k + 1])
+                bb[2 * i + 1] += zz[2 * k + 1] + (j - k) * (zz[2 * k + 3] - zz[2 * k + 1]) 
 
         snd.pos += ii * speed
 


### PR DESCRIPTION
Supporting **Volume** midi messages. Calculating the volume relatively to the state of the volume knob as sent by midi from time to time, also taking into account the sound-specific gain for each sound, if defined in the `definitions.txt` for that sound.

Upon **program-change**, resetting sound-specific gain, however maintaining the volume setting as set by the volume knob (midi) between program changes.

Supporting the **Pitchbend** wheel. Bending the pitch up and down by the `PITCHBAND_NOTE_RANGE` (i.e. the number of notes to bend up or down), as defined in the `config.py`. 
Note: this requires a rebuild of the C code by running: `python3 setup.py build_ext --inplace` to update the `samplerbox_audio.cpython-37m-arm-linux-gnueabihf.so` file. 
You might need to remove the above file and `samplerbox_audio.c` if the rebuild fails. 

Also, added IGNORE_MIDI_DEVICES to `config.py` and supported to solve the "_MidiInAlsa::alsaMidiHandler: unknown MIDI input error!_" issue caused by unused MIDI ports, which also causes for lingering and/or missing notes when playing. 