### PR TITLE
Multilayering and midi-split

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,11 +4,13 @@
 #########################################
 
 AUDIO_DEVICE_ID = 2                     # change this number to use another soundcard
-SAMPLES_DIR = "/media/"                 # The root directory containing the sample-sets. Example: "/media/" to look for samples on a USB stick / SD card
+SAMPLES_DIR = "."                       # The root directory containing the sample-sets. Example: "/media/" to look for samples on a USB stick / SD card
 MAX_POLYPHONY = 80                      # This can be set higher, but 80 is a safe value
-USE_BUTTONS = False                      # Set to True to use momentary buttons (connected to RaspberryPi's GPIO pins) to change preset
-USE_I2C_7SEGMENTDISPLAY = False          # Set to True to use a 7-segment display via I2C
-USE_SERIALPORT_MIDI = False              # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
+USE_BUTTONS = False                     # Set to True to use momentary buttons (connected to RaspberryPi's GPIO pins) to change preset
+USE_I2C_7SEGMENTDISPLAY = False         # Set to True to use a 7-segment display via I2C
+USE_SERIALPORT_MIDI = False             # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
 USE_SYSTEMLED = False                   # Flashing LED after successful boot, only works on RPi/Linux
+SERIALPORT_PORT = '/dev/ttyAMA0'
+SERIALPORT_BAUDRATE = 31250
 PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
 

--- a/config.py
+++ b/config.py
@@ -4,11 +4,11 @@
 #########################################
 
 AUDIO_DEVICE_ID = 2                     # change this number to use another soundcard
-SAMPLES_DIR = "."                       # The root directory containing the sample-sets. Example: "/media/" to look for samples on a USB stick / SD card
+SAMPLES_DIR = "/media/"                 # The root directory containing the sample-sets. Example: "/media/" to look for samples on a USB stick / SD card
 MAX_POLYPHONY = 80                      # This can be set higher, but 80 is a safe value
-USE_BUTTONS = False                     # Set to True to use momentary buttons (connected to RaspberryPi's GPIO pins) to change preset
-USE_I2C_7SEGMENTDISPLAY = False         # Set to True to use a 7-segment display via I2C
-USE_SERIALPORT_MIDI = False             # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
+USE_BUTTONS = False                      # Set to True to use momentary buttons (connected to RaspberryPi's GPIO pins) to change preset
+USE_I2C_7SEGMENTDISPLAY = False          # Set to True to use a 7-segment display via I2C
+USE_SERIALPORT_MIDI = False              # Set to True to enable MIDI IN via SerialPort (e.g. RaspberryPi's GPIO UART pins)
 USE_SYSTEMLED = False                   # Flashing LED after successful boot, only works on RPi/Linux
-SERIALPORT_PORT = '/dev/ttyAMA0'
-SERIALPORT_BAUDRATE = 31250
+PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
+

--- a/config.py
+++ b/config.py
@@ -13,5 +13,5 @@ USE_SYSTEMLED = False                   # Flashing LED after successful boot, on
 SERIALPORT_PORT = '/dev/ttyAMA0'
 SERIALPORT_BAUDRATE = 31250
 PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
-IGNORE_MIDI_DEVICES =  [b'Impulse 20:1', b'Impulse 20:2']
+IGNORE_MIDI_DEVICES =  []               # Ignore MIDI devices to avoid midi errors and missing/lingering notes. For example: [b'Impulse 20:1', b'Impulse 20:2']
 

--- a/config.py
+++ b/config.py
@@ -13,4 +13,5 @@ USE_SYSTEMLED = False                   # Flashing LED after successful boot, on
 SERIALPORT_PORT = '/dev/ttyAMA0'
 SERIALPORT_BAUDRATE = 31250
 PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
+IGNORE_MIDI_DEVICES =  [b'Impulse 20:1', b'Impulse 20:2']
 

--- a/config.py
+++ b/config.py
@@ -14,4 +14,5 @@ SERIALPORT_PORT = '/dev/ttyAMA0'
 SERIALPORT_BAUDRATE = 31250
 PITCHBAND_NOTE_RANGE = 2                # Pitchband note range, each direction
 IGNORE_MIDI_DEVICES =  []               # Ignore MIDI devices to avoid midi errors and missing/lingering notes. For example: [b'Impulse 20:1', b'Impulse 20:2']
+AUTO_LOAD_PROGRAMS =  []                # Upon start, automatically load the programs into midi channels, starting with 1. For example: [1,2,10,6,2] will go to MIDI channels 1-5 respectively. Must not exceed 16 items. 
 

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -226,13 +226,13 @@ def MidiCallback(message, time_stamp):
 LoadingThread = None
 LoadingInterrupt = False
 
-def LoadSamples():
+def LoadSamples(batch = False):
     global globalpreset
     global globalcurrentmidichannel
     global LoadingThread
     global LoadingInterrupt
 
-    if LoadingThread:
+    if not batch and LoadingThread:
         LoadingInterrupt = True
         LoadingThread.join()
         LoadingThread = None
@@ -241,6 +241,7 @@ def LoadSamples():
     LoadingThread = threading.Thread(target=ActuallyLoad, kwargs = {"preset": globalpreset, "midichannel": globalcurrentmidichannel})
     LoadingThread.daemon = True
     LoadingThread.start()
+
 
 NOTES = ["c", "c#", "d", "d#", "e", "f", "f#", "g", "g#", "a", "a#", "b"]
 
@@ -258,7 +259,7 @@ def ActuallyLoad(preset, midichannel):
     if basename:
         dirname = os.path.join(samplesdir, basename)
     if not basename:
-        print('Channel %s preset empty: %s' % (channel, preset))
+        print('Channel %s preset empty: %s' % (midichannel, preset))
         display("E%03d" % preset) # TBD support channel
         return
     print('Channel %s preset loading: %s (%s)' % (midichannel, preset, basename))
@@ -428,9 +429,17 @@ if USE_SERIALPORT_MIDI:
 #
 #########################################
 
-globalpreset = 0
-globalcurrentmidichannel = 1
-LoadSamples()
+if AUTO_LOAD_PROGRAMS and len(AUTO_LOAD_PROGRAMS) >= 1 and len(AUTO_LOAD_PROGRAMS) <= 16:
+    midichannel = 1
+    for program in AUTO_LOAD_PROGRAMS:
+        globalcurrentmidichannel = midichannel
+        midichannel += 1
+        globalpreset = program
+        LoadSamples(True)
+else:
+    globalpreset = 0
+    globalcurrentmidichannel = 1
+    LoadSamples()
 
 #########################################
 # SYSTEM LED

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -441,7 +441,7 @@ midi_in = [rtmidi.MidiIn(b'in')]
 previous = []
 while True:
     for port in midi_in[0].ports:
-        if port not in previous and b'Midi Through' not in port:
+        if port not in IGNORE_MIDI_DEVICES and port not in previous and b'Midi Through' not in port:
             midi_in.append(rtmidi.MidiIn(b'in'))
             midi_in[-1].callback = MidiCallback
             midi_in[-1].open_port(port)

--- a/samplerbox.py
+++ b/samplerbox.py
@@ -147,7 +147,7 @@ sustainplayingnotes = []
 sustain = False
 playingsounds = []
 globalvolume = globalsoundvolume = DEFAULT_VOLUME = 10 ** (-12.0/20)  # -12dB default global volume
-globalvolumeknob = 64
+globalvolumeknob = 127
 globaltranspose = 0
 pitchbend = 0
 

--- a/samplerbox_audio.pyx
+++ b/samplerbox_audio.pyx
@@ -61,17 +61,17 @@ def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndar
         else:
             ii = 0            
             for i in range(N):
-                j = pos + ii * speed 
+                j = pos + ii * speed
                 ii += 1                  
                 k = <int> j
                 if k > length - 2:
                     pos = looppos + 1
                     snd.pos = pos
                     ii = 0
-                    j = pos + ii * speed  
+                    j = pos + ii * speed
                     k = <int> j  
                 bb[2 * i] += zz[2 * k] + (j - k) * (zz[2 * k + 2] - zz[2 * k])                                               # linear interpolation
-                bb[2 * i + 1] += zz[2 * k + 1] + (j - k) * (zz[2 * k + 3] - zz[2 * k + 1]) 
+                bb[2 * i + 1] += zz[2 * k + 1] + (j - k) * (zz[2 * k + 3] - zz[2 * k + 1])
 
         snd.pos += ii * speed
 

--- a/samplerbox_audio.pyx
+++ b/samplerbox_audio.pyx
@@ -14,7 +14,7 @@ import cython
 import numpy
 cimport numpy
 
-def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndarray FADEOUT, int FADEOUTLENGTH, numpy.ndarray SPEED):
+def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndarray FADEOUT, int FADEOUTLENGTH, numpy.ndarray SPEED, pitchbend, pitchbandnoterange):
     cdef int i, ii, k, l, N, length, looppos, fadeoutpos
     cdef float speed, newsz, pos, j
     cdef numpy.ndarray b = numpy.zeros(2 * frame_count, numpy.float32)      # output buffer
@@ -29,7 +29,8 @@ def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndar
         looppos = snd.sound.loop
         length = snd.sound.nframes
         speed = SPEED[snd.note - snd.sound.midinote]
-        newsz = frame_count * speed
+        speed += (SPEED[snd.note - snd.sound.midinote + pitchbandnoterange] - speed) * pitchbend / 64
+        newsz = frame_count * speed 
         z = snd.sound.data
         zz = <short *> (z.data)
 
@@ -60,17 +61,17 @@ def mixaudiobuffers(list playingsounds, list rmlist, int frame_count, numpy.ndar
         else:
             ii = 0            
             for i in range(N):
-                j = pos + ii * speed
+                j = pos + ii * speed 
                 ii += 1                  
                 k = <int> j
                 if k > length - 2:
                     pos = looppos + 1
                     snd.pos = pos
                     ii = 0
-                    j = pos + ii * speed   
+                    j = pos + ii * speed  
                     k = <int> j  
                 bb[2 * i] += zz[2 * k] + (j - k) * (zz[2 * k + 2] - zz[2 * k])                                               # linear interpolation
-                bb[2 * i + 1] += zz[2 * k + 1] + (j - k) * (zz[2 * k + 3] - zz[2 * k + 1])
+                bb[2 * i + 1] += zz[2 * k + 1] + (j - k) * (zz[2 * k + 3] - zz[2 * k + 1]) 
 
         snd.pos += ii * speed
 


### PR DESCRIPTION
Supporting loading separate sounds for each midi channel, default to midi channel 1.
Playing samples by channel, all subject to the same rules (volume, pitchbend, sustain, fadeout)

If your keyboard supports sending notes on all or multiple channels (multizoning), they will be played by all samples that are loaded for these channels for each note (multilayering).

If your keyboard supports midi-split (zoning), samples from different sounds would be played for each note, corresponding to the midi channel of each note. 

Also, added support for AUTO_LOAD_PROGRAMS array in the config, allowing to set a list of programs to load automatically upon start, into midi channels 1-16. 

Yet to support:
1. Display on the USE_I2C_7SEGMENTDISPLAY (thinking to alternate the display between channel and program every 0.5 second)
2. Support for hardware buttons to change midi-channel to load multilayered sounds (thinking to allow a dual-click on both buttons to toggle between setting midi channel and program)

Limits: RAM capacity. 

Once approved, I will update the README file. 

I already used the upgraded version in rehersal with my band tonight and it sounds very good, on a raspberry pi 2b!

Thank you!